### PR TITLE
[WIP] Builder для запросов расписания

### DIFF
--- a/ClientSamgk/ClientSamgk.csproj
+++ b/ClientSamgk/ClientSamgk.csproj
@@ -13,7 +13,7 @@
         <Authors>kulagin</Authors>
         <AssemblyName>ClientSamgk</AssemblyName>
         <RootNamespace>ClientSamgk</RootNamespace>
-        <Version>2.7.8</Version>
+        <Version>3.0.0</Version>
         <PackageTags>samgk api client</PackageTags>
         <PackageProjectUrl>samgk.ru</PackageProjectUrl>
         <RepositoryUrl>https://github.com/TheCrazyWolf/Api-Client-for-samgk.ru</RepositoryUrl>

--- a/ClientSamgk/Common/CommonCache.cs
+++ b/ClientSamgk/Common/CommonCache.cs
@@ -7,35 +7,39 @@ using ClientSamgkOutputResponse.Interfaces.Schedule;
 
 namespace ClientSamgk.Common;
 
-public class CommonCache 
+public class CommonCache
 {
     protected int DefaultLifeTimeInMinutesForCommon = 2880; // 2 дня
     protected int DefaultLifeTimeInMinutesLong = 43200; // 1 месяц
     protected int DefaultLifeTimeInMinutesShort = 10; // 10минут
-    
-    protected IList<LifeTimeMemory<IResultOutScheduleFromDate>> ScheduleCache = new List<LifeTimeMemory<IResultOutScheduleFromDate>>();
+
+    protected IList<LifeTimeMemory<IResultOutScheduleFromDate>> ScheduleCache =
+        new List<LifeTimeMemory<IResultOutScheduleFromDate>>();
+
     protected IList<LifeTimeMemory<IResultOutCab>> CabsCache = new List<LifeTimeMemory<IResultOutCab>>();
     protected IList<LifeTimeMemory<IResultOutGroup>> GroupsCache = new List<LifeTimeMemory<IResultOutGroup>>();
     protected IList<LifeTimeMemory<IResultOutIdentity>> IdentityCache = new List<LifeTimeMemory<IResultOutIdentity>>();
-    
+
     public IResultOutScheduleFromDate? ExtractFromCache(DateOnly date, ScheduleSearchType type, string? id)
     {
         ClearCacheIfOutDate();
-        return ScheduleCache.FirstOrDefault(x => x.Object.Date == date && x.Object.SearchType == type && x.Object.IdValue == id)?.Object;
+        return ScheduleCache
+            .FirstOrDefault(x => x.Object.Date == date && x.Object.SearchType == type && x.Object.IdValue == id)
+            ?.Object;
     }
-    
+
     public IResultOutCab? ExtractCabFromCache(string? id)
     {
         ClearCacheIfOutDate();
         return CabsCache.FirstOrDefault(x => x.Object.Adress == id)?.Object;
     }
-    
+
     public IResultOutGroup? ExtractGroupFromCache(long? id)
     {
         ClearCacheIfOutDate();
         return GroupsCache.FirstOrDefault(x => x.Object.Id == id)?.Object;
     }
-    
+
     public IResultOutIdentity? ExtractIdentityFromCache(long? id)
     {
         ClearCacheIfOutDate();
@@ -52,7 +56,7 @@ public class CommonCache
         };
         ScheduleCache.Add(item);
     }
-    
+
     protected void SaveToCache(IResultOutIdentity identity, int lifeTimeInMinutes)
     {
         var item = new LifeTimeMemory<IResultOutIdentity>()
@@ -63,7 +67,7 @@ public class CommonCache
         };
         IdentityCache.Add(item);
     }
-    
+
     protected void SaveToCache(IResultOutGroup schedule, int lifeTimeInMinutes)
     {
         var item = new LifeTimeMemory<IResultOutGroup>()
@@ -74,7 +78,7 @@ public class CommonCache
         };
         GroupsCache.Add(item);
     }
-    
+
     protected void SaveToCache(IResultOutCab schedule, int lifeTimeInMinutes)
     {
         var item = new LifeTimeMemory<IResultOutCab>()
@@ -92,16 +96,17 @@ public class CommonCache
         {
             ScheduleCache.Remove(item);
         }
-        
+
         foreach (var item in CabsCache.Where(x => DateTime.Now >= x.DateTimeCanBeDeleted).ToList())
         {
             CabsCache.Remove(item);
         }
-        
+
         foreach (var item in GroupsCache.Where(x => DateTime.Now >= x.DateTimeCanBeDeleted).ToList())
         {
             GroupsCache.Remove(item);
         }
+
         foreach (var item in IdentityCache.Where(x => DateTime.Now >= x.DateTimeCanBeDeleted).ToList())
         {
             IdentityCache.Remove(item);

--- a/ClientSamgk/Common/CommonSamgkController.cs
+++ b/ClientSamgk/Common/CommonSamgkController.cs
@@ -17,19 +17,19 @@ public class CommonSamgkController : CommonCache
 {
     private readonly RestClient _client = new(new HttpClient());
 
-    private async Task<RestResponse?> SendRequestAndGetResponse(string url, Method method = Method.Get,
-        object? body = null)
+    private async Task<RestResponse?> SendRequestAndGetResponse(Uri url, Method method = Method.Get,
+        object? body = null, CancellationToken cToken = default)
     {
         var options = new RestRequest(url);
         options.ConfigureAntiGreedHeaders();
         if (body is not null && method is Method.Post or Method.Put) options.AddBody(body);
-        return await _client.ExecuteAsync(options, method).ConfigureAwait(false);
+        return await _client.ExecuteAsync(options, method, cToken).ConfigureAwait(false);
     }
 
 
-    protected async Task<T?> SendRequest<T>(string url, Method method = Method.Get, object? body = null)
+    protected async Task<T?> SendRequest<T>(Uri url, Method method = Method.Get, object? body = null, CancellationToken cToken = default)
     {
-        var restResponse = await SendRequestAndGetResponse(url, method, body).ConfigureAwait(false);
+        var restResponse = await SendRequestAndGetResponse(url, method, body, cToken).ConfigureAwait(false);
         if (restResponse is null || !restResponse.IsSuccessStatusCode || restResponse.Content == null) return default;
         return TryDeserializeObjectOrGetDefault<T>(restResponse.Content);
     }
@@ -46,23 +46,23 @@ public class CommonSamgkController : CommonCache
         }
     }
 
-    protected async Task SendRequest(string url, Method method = Method.Get, object? body = null)
+    protected async Task SendRequest(Uri url, Method method = Method.Get, object? body = null)
     {
         await SendRequestAndGetResponse(url, method, body);
     }
 
-    protected async Task UpdateIfCacheIsOutdated()
+    protected async Task UpdateIfCacheIsOutdated(CancellationToken cToken = default)
     {
         if (!IsRequiredToForceUpdateCache()) return;
 
-        await ConfiguringCacheTeachers().ConfigureAwait(false);
-        await ConfiguringCacheCabs().ConfigureAwait(false);
-        await ConfiguringCacheGroups().ConfigureAwait(false);
+        await ConfiguringCacheTeachers(cToken).ConfigureAwait(false);
+        await ConfiguringCacheCabs(cToken).ConfigureAwait(false);
+        await ConfiguringCacheGroups(cToken).ConfigureAwait(false);
     }
 
-    private async Task ConfiguringCacheGroups()
+    private async Task ConfiguringCacheGroups(CancellationToken cToken = default)
     {
-        var resultApiGroups = await SendRequest<IList<SamGkGroupApiResult>>("https://mfc.samgk.ru/api/groups").ConfigureAwait(false);
+        var resultApiGroups = await SendRequest<IList<SamGkGroupApiResult>>(new Uri("https://mfc.samgk.ru/api/groups"), cToken: cToken).ConfigureAwait(false);
 
         if (resultApiGroups == null || !resultApiGroups.Any()) return;
 
@@ -82,9 +82,9 @@ public class CommonSamgkController : CommonCache
         foreach (var item in items) SaveToCache(item, DefaultLifeTimeInMinutesForCommon);
     }
 
-    private async Task ConfiguringCacheTeachers()
+    private async Task ConfiguringCacheTeachers(CancellationToken cToken = default)
     {
-        var resultApiTeachers = await SendRequest<IList<SamgkTeacherApiResult>>("https://mfc.samgk.ru/api/teachers").ConfigureAwait(false);
+        var resultApiTeachers = await SendRequest<IList<SamgkTeacherApiResult>>(new Uri("https://mfc.samgk.ru/api/teachers"), cToken: cToken).ConfigureAwait(false);
 
         if (resultApiTeachers == null || !resultApiTeachers.Any()) return;
 
@@ -102,9 +102,9 @@ public class CommonSamgkController : CommonCache
         foreach (var item in items) SaveToCache(item, DefaultLifeTimeInMinutesForCommon);
     }
 
-    private async Task ConfiguringCacheCabs()
+    private async Task ConfiguringCacheCabs(CancellationToken cToken = default)
     {
-        var resultApiCabs = await SendRequest<Dictionary<string, string>>("https://mfc.samgk.ru/api/cabs").ConfigureAwait(false);
+        var resultApiCabs = await SendRequest<Dictionary<string, string>>(new Uri("https://mfc.samgk.ru/api/cabs"), cToken: cToken).ConfigureAwait(false);
 
         if (resultApiCabs == null || !resultApiCabs.Any()) return;
 

--- a/ClientSamgk/Controllers/ScheduleController.cs
+++ b/ClientSamgk/Controllers/ScheduleController.cs
@@ -14,171 +14,13 @@ namespace ClientSamgk.Controllers;
 
 public class ScheduleController : CommonSamgkController, ISсheduleController
 {
-    public IResultOutScheduleFromDate GetSchedule(DateOnly date, IResultOutIdentity entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false)
+
     {
-        return GetScheduleAsync(date: date, type: ScheduleSearchType.Employee, entity.Id.ToString(), overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
     }
 
-    public async Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, IResultOutIdentity entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false)
     {
-        return await GetScheduleAsync(date: date, type: ScheduleSearchType.Employee, entity.Id.ToString(), overrideCache: overrideCache);
-    }
 
-    public IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate,
-        IResultOutIdentity entity, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false,
-        int delay = 700)
-    {
-        return GetScheduleAsync(startDate: startDate, endDate: endDate, type: ScheduleSearchType.Employee,
-                entity.Id.ToString(), delay: delay, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
 
-    public async Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
-        IResultOutIdentity entity, ScheduleCallType scheduleCallType = ScheduleCallType.Standart, bool overrideCache = false,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, int delay = 700)
-    {
-        return await GetScheduleAsync(startDate: startDate, endDate: endDate, type: ScheduleSearchType.Employee,
-            entity.Id.ToString(), delay: delay, overrideCache: overrideCache);
-    }
-
-    public IResultOutScheduleFromDate GetSchedule(DateOnly date, IResultOutGroup entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false)
-    {
-        return GetScheduleAsync(date: date, type: ScheduleSearchType.Group,
-                entity.Id.ToString(), overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    public async Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, IResultOutGroup entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false)
-    {
-        return await GetScheduleAsync(date: date, type: ScheduleSearchType.Group,
-            entity.Id.ToString(), overrideCache: overrideCache);
-    }
-
-    public IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, IResultOutGroup entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false,
-        int delay = 700)
-    {
-        return GetScheduleAsync(startDate: startDate, endDate: endDate, type: ScheduleSearchType.Group,
-                entity.Id.ToString(), delay: delay, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    public async Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
-        IResultOutGroup entity, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false,
-        int delay = 700)
-    {
-        return await GetScheduleAsync(startDate: startDate, endDate: endDate, type: ScheduleSearchType.Group,
-            entity.Id.ToString(), delay: delay, scheduleCallType: scheduleCallType,
-            showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache);
-    }
-
-    public IResultOutScheduleFromDate GetSchedule(DateOnly date, IResultOutCab entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart, bool overrideCache = false,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true)
-    {
-        return GetScheduleAsync(date: date, type: ScheduleSearchType.Cab,
-                entity.Adress, scheduleCallType: scheduleCallType,
-                showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    public async Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, IResultOutCab entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart, bool overrideCache = false,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true)
-    {
-        return await GetScheduleAsync(date: date, type: ScheduleSearchType.Cab,
-            entity.Adress, scheduleCallType: scheduleCallType,
-            showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache);
-    }
-
-    public IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, IResultOutCab entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart, bool overrideCache = false,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true,
-        int delay = 700)
-    {
-        return GetScheduleAsync(startDate: startDate, endDate: endDate, type: ScheduleSearchType.Cab,
-                entity.Adress, delay: delay, scheduleCallType: scheduleCallType,
-                showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    public async Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
-        IResultOutCab entity, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false,
-        int delay = 700)
-    {
-        return await GetScheduleAsync(startDate: startDate, endDate: endDate, type: ScheduleSearchType.Cab,
-            entity.Adress, delay: delay, scheduleCallType: scheduleCallType,
-            showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache);
-    }
-
-    public IResultOutScheduleFromDate GetSchedule(DateOnly date, ScheduleSearchType type, string id,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false)
-    {
-        return GetScheduleAsync(date: date, type: type, id: id, scheduleCallType: scheduleCallType,
-                showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    public IResultOutScheduleFromDate GetSchedule(DateOnly date, ScheduleSearchType type, long id,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false)
-    {
-        return GetScheduleAsync(date: date, type: type, id: id.ToString(), scheduleCallType: scheduleCallType,
-                showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    public async Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, ScheduleSearchType type, long id,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false)
-    {
-        return await GetScheduleAsync(date: date, type: type, id: id.ToString(), scheduleCallType: scheduleCallType,
-            showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache);
-    }
-
-    public IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, ScheduleSearchType type,
-        string id, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700)
-    {
-        return GetScheduleAsync(startDate: startDate, endDate: endDate, type: type, id: id, delay: delay,
-                scheduleCallType: scheduleCallType,
-                showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
-
-    public IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, ScheduleSearchType type,
-        long id, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700)
-    {
-        return GetScheduleAsync(startDate: startDate, endDate: endDate, type: type, id: id, delay: delay,
-                scheduleCallType: scheduleCallType,
-                showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
-    }
 
     public async Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
         ScheduleSearchType type, string id, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
@@ -200,16 +42,6 @@ public class ScheduleController : CommonSamgkController, ISсheduleController
         }
 
         return resultOutScheduleFromDates;
-    }
-
-    public async Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
-        ScheduleSearchType type, long id, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700)
-    {
-        return await GetScheduleAsync(startDate: startDate, endDate: endDate, type: type, id: id.ToString(),
-            delay: delay, scheduleCallType: scheduleCallType,
-            showImportantLessons: showImportantLessons, showRussianHorizonLesson: showRussianHorizonLesson, overrideCache: overrideCache);
-    }
 
     public async Task<IList<IResultOutScheduleFromDate>> GetAllScheduleAsync(DateOnly date, ScheduleSearchType type,
         ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
@@ -266,14 +98,6 @@ public class ScheduleController : CommonSamgkController, ISсheduleController
         return result;
     }
 
-    public IList<IResultOutScheduleFromDate> GetAllSchedule(DateOnly date, ScheduleSearchType type,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700)
-    {
-        return GetAllScheduleAsync(date, type, ScheduleCallType.Standart, showImportantLessons,
-                showRussianHorizonLesson, delay:delay, overrideCache: overrideCache)
-            .GetAwaiter()
-            .GetResult();
     }
 
     public async Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, ScheduleSearchType type, string id,

--- a/ClientSamgk/Controllers/ScheduleController.cs
+++ b/ClientSamgk/Controllers/ScheduleController.cs
@@ -47,7 +47,7 @@ public class ScheduleController : CommonSamgkController, ISсheduleController
         var resultFromDates = await dates
             .SelectMany(date => ids.Select(id => (date, id)))
             .LoopAsyncResult<(DateOnly, string), IResultOutScheduleFromDate>(async pair =>
-                await RequestSchedule(query, pair.Item1, pair.Item2, cToken));
+                await RequestSchedule(query, pair.Item1, pair.Item2, cToken).ConfigureAwait(false));
 
         return resultFromDates.ToList();
     }
@@ -62,7 +62,8 @@ public class ScheduleController : CommonSamgkController, ISсheduleController
         }
 
         var url = GetScheduleUrl(query.SearchType, date, id);
-        var result = await SendRequest<Dictionary<string, Dictionary<string, List<ScheduleItem>>>>(url, cToken: cToken);
+        var result = await SendRequest<Dictionary<string, Dictionary<string, List<ScheduleItem>>>>(url, cToken: cToken)
+            .ConfigureAwait(false);
         var newSchedule = ParseScheduleResult(date, result, query);
         if (!query.OverrideCache)
             SaveToCache(newSchedule, newSchedule.Date < DateOnly.FromDateTime(DateTime.Now.Date)

--- a/ClientSamgk/Controllers/ScheduleController.cs
+++ b/ClientSamgk/Controllers/ScheduleController.cs
@@ -61,16 +61,17 @@ public class ScheduleController : CommonSamgkController, ISсheduleController
         return resultFromDates;
     }
 
-    private Uri GetScheduleUrl(ScheduleQuery query)
+    private Uri GetScheduleUrl(ScheduleSearchType searchType, DateOnly date, string id)
     {
-        ArgumentNullException.ThrowIfNull(query.SearchId);
+        ArgumentNullException.ThrowIfNull(id);
 
-        return query.SearchType switch
+        return searchType switch
         {
-            ScheduleSearchType.Employee => new Uri(_scheduleApiEndpointUri, $"?date={query.Date:yyyy-MM-dd}&teacher={query.SearchId}"),
-            ScheduleSearchType.Group => new Uri(_scheduleApiEndpointUri,$"?date={query.Date:yyyy-MM-dd}&group={query.SearchId}"),
-            ScheduleSearchType.Cab => new Uri(_scheduleApiEndpointUri,$"?date={query.Date:yyyy-MM-dd}&cab={query.SearchId}"),
-            _ => throw new ArgumentOutOfRangeException(nameof(query.SearchType))
+            ScheduleSearchType.Employee => new Uri(_scheduleApiEndpointUri,
+                $"?date={date:yyyy-MM-dd}&teacher={id}"),
+            ScheduleSearchType.Group => new Uri(_scheduleApiEndpointUri, $"?date={date:yyyy-MM-dd}&group={id}"),
+            ScheduleSearchType.Cab => new Uri(_scheduleApiEndpointUri, $"?date={date:yyyy-MM-dd}&cab={id}"),
+            _ => throw new ArgumentOutOfRangeException(nameof(searchType))
         };
     }
 

--- a/ClientSamgk/Controllers/ScheduleController.cs
+++ b/ClientSamgk/Controllers/ScheduleController.cs
@@ -7,7 +7,6 @@ using ClientSamgkOutputResponse.Enums;
 using ClientSamgkOutputResponse.Implementation.Education;
 using ClientSamgkOutputResponse.Implementation.Schedule;
 using ClientSamgkOutputResponse.Interfaces.Cabs;
-using ClientSamgkOutputResponse.Interfaces.Groups;
 using ClientSamgkOutputResponse.Interfaces.Identity;
 using ClientSamgkOutputResponse.Interfaces.Schedule;
 

--- a/ClientSamgk/Controllers/ScheduleController.cs
+++ b/ClientSamgk/Controllers/ScheduleController.cs
@@ -185,7 +185,7 @@ public class ScheduleController : CommonSamgkController, ISсheduleController
     private void AddTeachersToLesson(ScheduleItem scheduleItem, ResultOutResultOutLesson lesson)
     {
         foreach (var itemTeacher in scheduleItem.Teacher
-                     .Select(idTeacher => IdentityCache.Select(x=> x.Object).FirstOrDefault(x => x.Id == idTeacher))
+                     .Select(idTeacher => IdentityCache.Select(x => x.Object).FirstOrDefault(x => x.Id == idTeacher))
                      .OfType<IResultOutIdentity>())
         {
             lesson.Identity.Add(itemTeacher);
@@ -195,7 +195,7 @@ public class ScheduleController : CommonSamgkController, ISсheduleController
     private void AddCabsToLesson(ScheduleItem scheduleItem, ResultOutResultOutLesson lesson)
     {
         foreach (var itemCab in scheduleItem.Cab
-                     .Select(idCab => CabsCache.Select(x=> x.Object).FirstOrDefault(x => x.Adress == idCab))
+                     .Select(idCab => CabsCache.Select(x => x.Object).FirstOrDefault(x => x.Adress == idCab))
                      .OfType<IResultOutCab>())
         {
             lesson.Cabs.Add(itemCab);
@@ -207,20 +207,24 @@ public class ScheduleController : CommonSamgkController, ISсheduleController
     {
         var firstLesson = returnableResult.Lessons.FirstOrDefault();
 
+        var isFirstPair = firstLesson is { NumPair: 1, NumLesson: 1 } or { NumPair: 1, NumLesson: 0 };
+        var isNotInJuneJuly = date.Month != 6 && date.Month != 7;
+
         // Разговоры о важном
-        if (showImportantLessons && (firstLesson != null && (firstLesson.NumPair == 1 && firstLesson.NumLesson == 1 ||
-                                                             firstLesson.NumPair == 1 && firstLesson.NumLesson == 0)
-                                                         && date.DayOfWeek == DayOfWeek.Monday && date.Month != 6 &&
-                                                         date.Month != 7))
+        if (showImportantLessons
+            && isFirstPair
+            && date.DayOfWeek == DayOfWeek.Monday
+            && isNotInJuneJuly)
         {
             returnableResult.Lessons = returnableResult.Lessons.AddTalkImportantLesson().SortByLessons();
         }
 
         // россия мои горизонты
-        if (showRussianHorizonLesson && (firstLesson?.EducationGroup?.Course == 1
-                                         && (firstLesson.NumPair == 1 && firstLesson.NumLesson == 1 ||
-                                             firstLesson.NumPair == 1 && firstLesson.NumLesson == 0)
-                                         && date.DayOfWeek == DayOfWeek.Thursday && date.Month != 6 && date.Month != 7))
+        if (showRussianHorizonLesson
+            && firstLesson?.EducationGroup?.Course == 1
+            && isFirstPair
+            && date.DayOfWeek == DayOfWeek.Thursday
+            && isNotInJuneJuly)
         {
             returnableResult.Lessons = returnableResult.Lessons.AddRussianMyHorizonTalk().SortByLessons();
         }

--- a/ClientSamgk/Interfaces/Client/ISсheduleController.cs
+++ b/ClientSamgk/Interfaces/Client/ISсheduleController.cs
@@ -1,103 +1,11 @@
-using ClientSamgkOutputResponse.Enums;
-using ClientSamgkOutputResponse.Interfaces.Cabs;
-using ClientSamgkOutputResponse.Interfaces.Groups;
-using ClientSamgkOutputResponse.Interfaces.Identity;
+using ClientSamgk.Models;
 using ClientSamgkOutputResponse.Interfaces.Schedule;
 
 namespace ClientSamgk.Interfaces.Client;
 
 public interface ISсheduleController
 {
-    IResultOutScheduleFromDate GetSchedule(DateOnly date, IResultOutIdentity entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
+    public IList<IResultOutScheduleFromDate> GetSchedule(ScheduleQuery query);
 
-    Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, IResultOutIdentity entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, IResultOutIdentity entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false,
-        int delay = 700);
-
-    Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
-        IResultOutIdentity entity, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700);
-
-    IResultOutScheduleFromDate GetSchedule(DateOnly date, IResultOutGroup entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, IResultOutGroup entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, IResultOutGroup entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false,
-        int delay = 700);
-
-    Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
-        IResultOutGroup entity, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700);
-
-    IResultOutScheduleFromDate GetSchedule(DateOnly date, IResultOutCab entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, IResultOutCab entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, IResultOutCab entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false,
-        int delay = 700);
-
-    Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate, IResultOutCab entity,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false,
-        int delay = 700);
-
-    IResultOutScheduleFromDate GetSchedule(DateOnly date, ScheduleSearchType type, string id,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    IResultOutScheduleFromDate GetSchedule(DateOnly date, ScheduleSearchType type, long id,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, ScheduleSearchType type, string id,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    Task<IResultOutScheduleFromDate> GetScheduleAsync(DateOnly date, ScheduleSearchType type, long id,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false);
-
-    IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, ScheduleSearchType type,
-        string id, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700);
-
-    IList<IResultOutScheduleFromDate> GetSchedule(DateOnly startDate, DateOnly endDate, ScheduleSearchType type,
-        long id, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700);
-
-    Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
-        ScheduleSearchType type, string id, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700);
-
-    Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(DateOnly startDate, DateOnly endDate,
-        ScheduleSearchType type, long id, ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700);
-
-    Task<IList<IResultOutScheduleFromDate>>
-        GetAllScheduleAsync(DateOnly date, ScheduleSearchType type,
-            ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-            bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700);
-
-    IList<IResultOutScheduleFromDate> GetAllSchedule(DateOnly date, ScheduleSearchType type,
-        ScheduleCallType scheduleCallType = ScheduleCallType.Standart,
-        bool showImportantLessons = true, bool showRussianHorizonLesson = true, bool overrideCache = false, int delay = 700);
+    public Task<IList<IResultOutScheduleFromDate>> GetScheduleAsync(ScheduleQuery query, CancellationToken cToken = default);
 }

--- a/ClientSamgk/Models/ScheduleQuery.cs
+++ b/ClientSamgk/Models/ScheduleQuery.cs
@@ -1,0 +1,108 @@
+﻿using ClientSamgkOutputResponse.Enums;
+using ClientSamgkOutputResponse.Interfaces.Cabs;
+using ClientSamgkOutputResponse.Interfaces.Groups;
+using ClientSamgkOutputResponse.Interfaces.Identity;
+
+namespace ClientSamgk.Models;
+
+public sealed class ScheduleQuery
+{
+    public DateOnly? Date { get; private set; }
+    public DateOnly? StartDate { get; private set; }
+    public DateOnly? EndDate { get; private set; }
+
+    public ScheduleSearchType SearchType { get; private set; }
+    public bool WithAllForType { get; private set; }
+    public string? SearchId { get; private set; }
+
+    public ScheduleCallType ScheduleCallType { get; private set; } = ScheduleCallType.Standart;
+    public bool ShowImportantLessons { get; private set; } = true;
+    public bool ShowRussianHorizonLesson { get; private set; } = true;
+    public bool OverrideCache { get; private set; }
+    public int Delay { get; private set; } = 700;
+
+    public ScheduleQuery WithDate(DateOnly date)
+    {
+        Date = date;
+        return this;
+    }
+
+    public ScheduleQuery WithDateRange(DateOnly startDate, DateOnly endDate)
+    {
+        StartDate = startDate;
+        EndDate = endDate;
+        return this;
+    }
+
+    public ScheduleQuery WithEmployee(IResultOutIdentity employee)
+    {
+        SearchType = ScheduleSearchType.Employee;
+        SearchId = employee.Id.ToString();
+        return this;
+    }
+
+    public ScheduleQuery WithGroup(IResultOutGroup group)
+    {
+        SearchType = ScheduleSearchType.Group;
+        SearchId = group.Id.ToString();
+        return this;
+    }
+
+    public ScheduleQuery WithCab(IResultOutCab cab)
+    {
+        SearchType = ScheduleSearchType.Cab;
+        SearchId = cab.Adress;
+        return this;
+    }
+
+    public ScheduleQuery WithSearchType(ScheduleSearchType searchType, string id)
+    {
+        SearchType = searchType;
+        SearchId = id;
+        return this;
+    }
+
+    public ScheduleQuery WithSearchType(ScheduleSearchType searchType, long id)
+    {
+        SearchType = searchType;
+        SearchId = id.ToString();
+        return this;
+    }
+
+    public ScheduleQuery WithAllForSearchType(ScheduleSearchType searchType)
+    {
+        SearchType = searchType;
+        WithAllForType = true;
+        return this;
+    }
+
+    public ScheduleQuery WithScheduleCallType(ScheduleCallType scheduleCallType)
+    {
+        ScheduleCallType = scheduleCallType;
+        return this;
+    }
+
+    public ScheduleQuery ShowImportant(bool show = true)
+    {
+        ShowImportantLessons = show;
+        return this;
+    }
+
+    public ScheduleQuery ShowRussianHorizon(bool show = true)
+    {
+        ShowRussianHorizonLesson = show;
+        return this;
+    }
+
+    public ScheduleQuery WithOverrideCache(bool overrideCache = false)
+    {
+        OverrideCache = overrideCache;
+        return this;
+    }
+
+    public ScheduleQuery WithDelay(int delay)
+    {
+        Delay = delay;
+        return this;
+    }
+}

--- a/ClientSamgk/Models/ScheduleQuery.cs
+++ b/ClientSamgk/Models/ScheduleQuery.cs
@@ -82,13 +82,13 @@ public sealed class ScheduleQuery
         return this;
     }
 
-    public ScheduleQuery ShowImportant(bool show = true)
+    public ScheduleQuery WithShowImportant(bool show = true)
     {
         ShowImportantLessons = show;
         return this;
     }
 
-    public ScheduleQuery ShowRussianHorizon(bool show = true)
+    public ScheduleQuery WithShowRussianHorizon(bool show = true)
     {
         ShowRussianHorizonLesson = show;
         return this;

--- a/ClientSamgk/Utils/AdditionalLessonsExtensions.cs
+++ b/ClientSamgk/Utils/AdditionalLessonsExtensions.cs
@@ -12,56 +12,60 @@ public static class AdditionalLessonsExtensions
     {
         var newLesson = new ResultOutResultOutLesson
         {
-            NumLesson = 0, NumPair = 0, 
-            Durations = new List<DurationLessonDetails>() {new DurationLessonDetails(new TimeOnly(08,25),new TimeOnly(09,10))},
+            NumLesson = 0, NumPair = 0,
+            Durations = new List<DurationLessonDetails>
+                { new(new TimeOnly(08, 25), new TimeOnly(09, 10)) },
             SubjectDetails = new ResultOutSubject
             {
                 Id = 0,
                 Index = "КЧ.01",
                 SubjectName = "Классный час «Разговоры о важном»"
             },
-            Cabs = lesson.First().Cabs, EducationGroup = lesson.First().EducationGroup, 
+            Cabs = lesson.First().Cabs, EducationGroup = lesson.First().EducationGroup,
             Identity = lesson.First().Identity
         };
-        
+
         lesson.Add(newLesson);
         return lesson;
     }
-    
+
     public static IList<IResultOutLesson> AddRussianMyHorizonTalk(this IList<IResultOutLesson> lesson)
     {
         var newLesson = new ResultOutResultOutLesson
         {
-            NumLesson = 0, NumPair = 0, 
-            Durations = new List<DurationLessonDetails>() {new DurationLessonDetails(new TimeOnly(08,25),new TimeOnly(09,10))},
+            NumLesson = 0, NumPair = 0,
+            Durations = new List<DurationLessonDetails>
+                { new(new TimeOnly(08, 25), new TimeOnly(09, 10)) },
             SubjectDetails = new ResultOutSubject
             {
                 Id = 0,
                 Index = "КЧ.02",
                 SubjectName = "Классный час «Россия. Мои горизонты»"
             },
-            Cabs = lesson.First().Cabs, EducationGroup = lesson.First().EducationGroup, 
-            Identity = new List<IResultOutIdentity>(){ new ResultOutIdentity() { Id = 1923, Name = "Видинеев Дмитрий Юрьевич"}}
+            Cabs = lesson.First().Cabs, EducationGroup = lesson.First().EducationGroup,
+            Identity = new List<IResultOutIdentity>
+                { new ResultOutIdentity { Id = 1923, Name = "Видинеев Дмитрий Юрьевич" } }
         };
-        
+
         lesson.Add(newLesson);
         return lesson;
     }
-    
+
     public static IList<IResultOutLesson> SortByLessons(this IList<IResultOutLesson> lesson)
     {
         return lesson.OrderBy(x => x.NumPair).ThenBy(x => x.NumLesson).ToList();
     }
-    
+
     public static IList<IResultOutLesson> RemoveDuplicates(this IList<IResultOutLesson> lesson)
     {
-        return lesson.GroupBy(l => new {
+        return lesson.GroupBy(l => new
+            {
                 l.NumPair,
                 l.NumLesson,
                 l.EducationGroup?.Id,
-                SubjectName = l.SubjectDetails.FullSubjectName })
+                SubjectName = l.SubjectDetails.FullSubjectName
+            })
             .Select(g => g.First())
             .ToList();
     }
-
 }

--- a/ClientSamgk/Utils/DateTimeUtils.cs
+++ b/ClientSamgk/Utils/DateTimeUtils.cs
@@ -2,7 +2,7 @@
 
 public static class DateTimeUtils
 {
-    public static IReadOnlyList<DateOnly> GetDateRange(DateOnly startDate, DateOnly endDate)
+    public static IList<DateOnly> GetDateRange(DateOnly startDate, DateOnly endDate)
     {
         var daysCount = (endDate.ToDateTime(TimeOnly.MinValue) - startDate.ToDateTime(TimeOnly.MinValue)).Days + 1;
         var dateRange = new List<DateOnly>(daysCount);

--- a/ClientSamgk/Utils/DateTimeUtils.cs
+++ b/ClientSamgk/Utils/DateTimeUtils.cs
@@ -1,0 +1,17 @@
+﻿namespace ClientSamgk.Utils;
+
+public static class DateTimeUtils
+{
+    public static IReadOnlyList<DateOnly> GetDateRange(DateOnly startDate, DateOnly endDate)
+    {
+        var daysCount = (endDate.ToDateTime(TimeOnly.MinValue) - startDate.ToDateTime(TimeOnly.MinValue)).Days + 1;
+        var dateRange = new List<DateOnly>(daysCount);
+
+        for (var date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            dateRange.Add(date);
+        }
+
+        return dateRange;
+    }
+}

--- a/ClientSamgk/Utils/EnumerableUtils.cs
+++ b/ClientSamgk/Utils/EnumerableUtils.cs
@@ -1,0 +1,10 @@
+﻿namespace ClientSamgk.Utils;
+
+public static class EnumerableUtils
+{
+    public static async Task<IEnumerable<TOut>> LoopAsyncResult<TIn, TOut>(this IEnumerable<TIn> list, Func<TIn, Task<TOut>> function)
+    {
+        var loopResult = await Task.WhenAll(list.Select(function));
+        return loopResult.ToList().AsEnumerable();
+    }
+}

--- a/ClientSamgkExample/Program.cs
+++ b/ClientSamgkExample/Program.cs
@@ -1,6 +1,8 @@
 ﻿// See https://aka.ms/new-console-template for more information
 using ClientSamgk;
+using ClientSamgk.Controllers;
 using ClientSamgk.Interfaces.Client;
+using ClientSamgk.Models;
 using ClientSamgkOutputResponse.Enums;
 
 IClientSamgkApi api = new ClientSamgkApi();
@@ -13,7 +15,10 @@ var groupsTeachers = await api.Accounts.GetTeachersAsync();
 
 // Получение расписание за день
 DateOnly dateOnly = new DateOnly(2024,09,16);
-var scheduleFromDate = await api.Schedule.GetScheduleAsync(dateOnly, ScheduleSearchType.Employee, "2294");
+var query = new ScheduleQuery()
+    .WithDate(dateOnly)
+    .WithSearchType(ScheduleSearchType.Employee, "2294");
+var scheduleFromDate = await api.Schedule.GetScheduleAsync(query);
 
 // или с использованием объектов реализующих интерфейсы
 // IOutResultIdentity, IOutResultCab, IOutResultGroup
@@ -21,23 +26,33 @@ var obj = await api.Groups.GetGroupAsync("ис-23-01");
 
 if (obj is null) throw new Exception($"{nameof(obj)} is null)");
 
-scheduleFromDate = await api.Schedule.GetScheduleAsync(dateOnly, obj);
+query = new ScheduleQuery()
+    .WithDate(dateOnly)
+    .WithGroup(obj);
+scheduleFromDate = await api.Schedule.GetScheduleAsync(query);
     
 // Получение расписание диапозона дат
 DateOnly dateOnlyStart = new DateOnly(2024,09,16);
 DateOnly dateOnlyEnd = new DateOnly(2024,09,16);
 
+query = new ScheduleQuery()
+    .WithDateRange(dateOnlyStart, dateOnlyEnd)
+    .WithGroup(obj);
 var resultScheduleCollection = await api.Schedule
-    .GetScheduleAsync(dateOnlyStart, dateOnlyEnd, obj);
+    .GetScheduleAsync(query);
     
 // Получение расписание за день по преподавателям, кабинету или группам
 // долгая выгрузка
+query = new ScheduleQuery()
+    .WithDate(dateOnlyStart)
+    .WithAllForSearchType(ScheduleSearchType.Employee)
+    .WithDelay(1000);
 var resultScheduleCollectionFromDateAll = await api.Schedule
-    .GetAllScheduleAsync(dateOnlyStart, ScheduleSearchType.Employee, delay: 1000);
+    .GetScheduleAsync(query);
     
 // пример вывода расписания
 
-foreach (var item in scheduleFromDate.Lessons)
+foreach (var item in scheduleFromDate.FirstOrDefault().Lessons)
 {
     Console.WriteLine($"{item.NumPair}.{item.NumLesson} - {item.SubjectDetails.FullSubjectName}");
 }

--- a/ClientSamgkExample/Program.cs
+++ b/ClientSamgkExample/Program.cs
@@ -1,6 +1,5 @@
 ﻿// See https://aka.ms/new-console-template for more information
 using ClientSamgk;
-using ClientSamgk.Controllers;
 using ClientSamgk.Interfaces.Client;
 using ClientSamgk.Models;
 using ClientSamgkOutputResponse.Enums;
@@ -11,13 +10,13 @@ IClientSamgkApi api = new ClientSamgkApi();
 var groupsArray = await api.Groups.GetGroupsAsync();
 
 // Получить список преподавателей
-var groupsTeachers = await api.Accounts.GetTeachersAsync();
+var teachers = await api.Accounts.GetTeachersAsync();
 
 // Получение расписание за день
 DateOnly dateOnly = new DateOnly(2024,09,16);
 var query = new ScheduleQuery()
     .WithDate(dateOnly)
-    .WithSearchType(ScheduleSearchType.Employee, "2294");
+    .WithSearchType(ScheduleSearchType.Employee, 2294);
 var scheduleFromDate = await api.Schedule.GetScheduleAsync(query);
 
 // или с использованием объектов реализующих интерфейсы

--- a/ClientSamgkOutputResponse/Interfaces/Cabs/IResultOutCab.cs
+++ b/ClientSamgkOutputResponse/Interfaces/Cabs/IResultOutCab.cs
@@ -6,14 +6,14 @@ public interface IResultOutCab
     /// Полный адрес кабинета
     /// </summary>
     public string Adress { get; set; }
-    
+
     /// <summary>
     /// № Учебного корпуса
     /// </summary>
-    public string Campus { get;}
+    public string Campus { get; }
 
     /// <summary>
     /// Номер кабинета
     /// </summary>
-    public string Auditory { get;}
+    public string Auditory { get; }
 }

--- a/ClientSamgkOutputResponse/Interfaces/Groups/IResultOutGroup.cs
+++ b/ClientSamgkOutputResponse/Interfaces/Groups/IResultOutGroup.cs
@@ -8,15 +8,17 @@ public interface IResultOutGroup
     /// ID группы
     /// </summary>
     public long Id { get; set; }
+
     /// <summary>
     /// Название группы
     /// </summary>
     public string Name { get; set; }
+
     /// <summary>
     /// ID куратора группы, которые не работает и не совпадает с реальной жизнью
     /// </summary>
     public IResultOutIdentity? Currator { get; set; }
-    
+
     /// <summary>
     /// № курса обучения
     /// </summary>

--- a/ClientSamgkOutputResponse/Interfaces/Identity/IResultOutIdentity.cs
+++ b/ClientSamgkOutputResponse/Interfaces/Identity/IResultOutIdentity.cs
@@ -6,15 +6,14 @@ public interface IResultOutIdentity
     /// ID сотрудника
     /// </summary>
     public long Id { get; set; }
-    
+
     /// <summary>
     /// Фио преподавателя
     /// </summary>
     public string Name { get; set; }
-    
+
     /// <summary>
     /// Короткое имя в формате Фамилия И.О.
     /// </summary>
     public string ShortName { get; }
-    
 }


### PR DESCRIPTION
Переделка огромного числа перегрузок одного и того же метода в один метод с билдером 
з.ы. `GetSchedule`, `GetAllSchedule` теперь одно и тоже
Теперь доступен класс `ScheduleQuery` в котором благодаря _Fluent api_ можно точечетно настроить все параметры запроса.
Так же по мелочи: чистка, рефакторинг некоторых вещей

Пример:
```csharp
var query = new ScheduleQuery()
    .WithDate(dateOnlyStart)
    .WithAllForSearchType(ScheduleSearchType.Employee)
    .WithDelay(1000);
var resultScheduleCollectionFromDateAll = await api.Schedule.GetScheduleAsync(query);
```